### PR TITLE
openvmtools: add explicit hasstatus on vmware-tools service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,6 +126,7 @@ class openvmtools {
   service { "vmware-tools":
     ensure => stopped,
     enable => false,
+    hasstatus => false,
   }
 
 


### PR DESCRIPTION
In puppet 2.7.x, hasstatus defaults to true which will give an error when
we want to 'ensure => stopped' a service which might not be installed.
