### PR TITLE
Fix service pattern for Debian Squeeze

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,7 +115,10 @@ class openvmtools {
         ensure => running,
         enable => true,
         hasstatus => false,
-        pattern => "vmware-guestd --background",
+        pattern => $lsbdistcodename ? {
+                    'lenny' => "vmware-guestd --background",
+                    'squeeze' => 'vmtoolsd',
+                   },
         require => [Class["openvmtools::packages"], Package["open-vm-modules-$kernelrelease"], Exec["install open-vm-modules"], Service["vmware-tools"]],
       }
     }


### PR DESCRIPTION
Fix for debian squeeze that should have been fixed some time ago, I guess. This pull request includes the patch for the puppet 2.7 fix.
