### PR TITLE
init: set full path for dpkg command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,7 +108,7 @@ class openvmtools {
       exec { "install open-vm-modules":
         command => "module-assistant --text-mode auto-install open-vm-source",
         require => [Class["openvmtools::packages"], Class["buildenv::kernel"]],
-        unless  => "dpkg -s open-vm-modules-${kernelrelease} | grep '^Status: install ok installed'",
+        unless  => "/usr/bin/dpkg -s open-vm-modules-${kernelrelease} | grep '^Status: install ok installed'",
       }
 
       service { "open-vm-tools":


### PR DESCRIPTION
To avoid:
err: //Openvmtools/Exec[install open-vm-modules]: Could not evaluate: 'dpkg' is not executable
