### PR TITLE
Use template for install script

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@
 #
 class openvmtools (
   $ovt_version = $openvmtools::params::ovt_version,
+  $ovt_src_url = 'switch.dl.sourceforge.net/sourceforge/open-vm-tools',
 ) inherits ::openvmtools::params {
 
   include ::openvmtools::packages
@@ -69,7 +70,7 @@ class openvmtools (
             mode    => '0755',
             owner   => root,
             group   => root,
-            content => file('openvmtools/install-open-vm-tools.sh'),
+            content => template('openvmtools/install-open-vm-tools.sh.erb'),
           }
 
           file { '/etc/vmware-tools/open-vm-tools.version':

--- a/templates/install-open-vm-tools.sh.erb
+++ b/templates/install-open-vm-tools.sh.erb
@@ -23,12 +23,12 @@ if [ -f /etc/init.d/open-vm-tools ]; then
   /etc/init.d/open-vm-tools stop
 fi
 
-MIRROR="switch.dl.sourceforge.net"
+MIRROR=<%= ovt_src_url %>
 VER=$1
 WORKDIR=$(mktemp -d)
 BUILDLOG=/tmp/open-vm-tools-${VER}-build.log
 
-wget -qP $WORKDIR http://${MIRROR}/sourceforge/open-vm-tools/open-vm-tools-${VER}.tar.gz > /dev/null
+wget -qP $WORKDIR http://${MIRROR}/open-vm-tools-${VER}.tar.gz > /dev/null
 tar -C $WORKDIR -xzf $WORKDIR/open-vm-tools-${VER}.tar.gz || exit 1
 
 # bugfix for version 2009.07.22-179896. See


### PR DESCRIPTION
As the host switch.dl.sourceforge.net seems to have vanished, and I didn't find another one yet, I found this solution to provide a private URL to the required file.
This backward compatible patch allow to provide a different URL pointing to the open-vm-tools source package.
As the last RHEL distribution comes with an open-vm-tools package, it's just a fix for the old one (5&6).

Tested on RHEL5
TODO: test on RHEL6